### PR TITLE
Remove monkeypatch

### DIFF
--- a/ruby/sparql2.rb
+++ b/ruby/sparql2.rb
@@ -1,32 +1,10 @@
 # Ruby querying of the BioPortal triplestore using standard the RDF.rb family of libraries
-# Documentation for working with the RDF.rb SPARQL client can be found here: http://sparql.rubyforge.org/client/
-# The RDF.rb SPARQL client currently requires a monkeypatch to preserve query string parameters.
+# Documentation for working with the RDF.rb SPARQL client can be found here: https://github.com/ruby-rdf/sparql-client
 
 require 'rubygems'
 require 'sparql/client'
 
 apikey = ""
-
-# Monkeypatch to preserve query string parameters
-module SPARQL
-	class Client
-		attr_accessor :url
-
-    def get(query, headers = {}, &block)
-      url = self.url.dup
-      query_values = url.query_values.nil? || url.query_values.empty? ? {:query => query.to_s} : url.query_values.merge({:query => query.to_s})
-      url.query_values = query_values
-
-      request = Net::HTTP::Get.new(url.request_uri, @headers.merge(headers))
-      response = @http.request url, request
-      if block_given?
-				block.call(response)
-      else
-				response
-      end
-    end
-	end
-end
 
 endpoint = SPARQL::Client.new("http://sparql.bioontology.org/sparql/?apikey=#{apikey}")
 


### PR DESCRIPTION
sparql-client gem supports passing along query string parameters in the repository instantiation so we don't need to do the monkeypatching anymore. Makes the example much cleaner.
